### PR TITLE
prevent conflict with version set in lib/Moonpig/UserAgent.pm

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -7,3 +7,4 @@ copyright_year   = 2012
 [@Filter]
 -bundle = @RJBS
 -remove = UploadToCPAN
+-remove = PkgVersion


### PR DESCRIPTION
Without this change, `dzil listdeps` fails with:

```
[@Filter/PkgVersion] existing assignment to $VERSION in lib/Moonpig/UserAgent.pm
[@Filter/PkgVersion] existing assignment to $VERSION in lib/Moonpig/UserAgent.pm at /home/mjd/lib/perl/lib/perl5/x86_64-linux/Moose/Meta/Method/Delegation.pm line 110.
```

and `dzil test` fails similarly.
